### PR TITLE
fix 404 error when fetching web3modal from unpkg

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
     -->
 
     <script src="https://unpkg.com/web3@latest/dist/web3.min.js"></script>
-    <script type="text/javascript" src="https://unpkg.com/web3modal/lib/index.js"></script>
+    <script type="text/javascript" src="https://unpkg.com/web3modal"></script>
     <script type="text/javascript" src="https://unpkg.com/evm-chains/lib/index.js"></script>
     <script type="text/javascript" src="https://unpkg.com/@walletconnect/web3-provider/lib/index.js"></script>
     <script type="text/javascript" src="https://unpkg.com/fortmatic@2.0.6/dist/fortmatic.js"></script>


### PR DESCRIPTION
Hello, I applied this fix to get the web3modal example to work on my end, it was unable to fetch the dist from unpckg

![image](https://user-images.githubusercontent.com/26343/84560324-61189000-ad75-11ea-9763-daa75aa152f8.png)
